### PR TITLE
Implement `reading_time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "words-count",
 ]
 
 [[package]]
@@ -2129,6 +2130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "words-count"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28653ddaede5475c44a03e4014ae19f35aa9b231c423228b28963cb873e4869"
+dependencies = [
+ "unicode-blocks",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ regex = "1.11.1"
 rstest = "0.24.0"
 serde = "1.0.217"
 serde_json = "1.0.138"
+words-count = "0.1.6"
 
 [[bin]]
 name = "mdbook-ai-pocket-reference"


### PR DESCRIPTION
- Pretty primitive here:
- reading time is computed in mins
- use a specified rate `WORDS_PER_MINUTE` = 200 words per min (as default, non-configurable at this time)
- computed reading time as num_words (in chapter) / words_per_min
- use `words_count` crate to compute number of words in a chapter