### PR TITLE
[Fix] Remove extra-line in MD Link HTML template

### DIFF
--- a/src/ai_pocket_reference.rs
+++ b/src/ai_pocket_reference.rs
@@ -555,7 +555,7 @@ mod tests {
 
         let html_string = link.render()?;
         let expected = "<a href=\"https://fake.io\" target=\"_blank\" \
-        rel=\"noopener noreferrer\">some text</a>\n";
+        rel=\"noopener noreferrer\">some text</a>";
 
         assert_eq!(html_string, expected);
 
@@ -570,7 +570,7 @@ mod tests {
 
         let new_content = replace_all_md_links(content);
         let expected = "This is <a href=\"https://good.io\" target=\"_blank\" \
-         rel=\"noopener noreferrer\">good link</a>\n, whereas ![this](https://not-covered.io), \
+         rel=\"noopener noreferrer\">good link</a>, whereas ![this](https://not-covered.io), \
          and neither is \\[this\\](http://not-covered.io).";
 
         assert_eq!(new_content, expected);

--- a/src/ai_pocket_reference.rs
+++ b/src/ai_pocket_reference.rs
@@ -305,7 +305,7 @@ impl<'a> MDLink<'a> {
 
         // register template
         handlebars
-            .register_template_string("md_link_expansion", MDLINK_TEMPLATE)
+            .register_template_string("md_link_expansion", MDLINK_TEMPLATE.trim())
             .unwrap();
 
         // create data for rendering handlebar


### PR DESCRIPTION
This PR fixes an issue where the md link html template adds a new line after the html expansion. Its noticeable in lists:

<img width="547" alt="image" src="https://github.com/user-attachments/assets/7eaa5e1c-560f-4421-98fc-a95ed78fd70a" />
